### PR TITLE
[DRAFT] Can I use native lazy loading?

### DIFF
--- a/test/integration/image-component/basic/test/index.test.js
+++ b/test/integration/image-component/basic/test/index.test.js
@@ -124,6 +124,9 @@ function lazyLoadingTests() {
     expect(
       await browser.elementById('lazy-bottom').getAttribute('srcset')
     ).toBeFalsy()
+    expect(
+      await browser.elementById('lazy-bottom').getAttribute('loading')
+    ).toBe('lazy')
   })
   it('should load the third image, which is unoptimized, after scrolling further down', async () => {
     let viewportHeight = await browser.eval(`window.innerHeight`)


### PR DESCRIPTION
> This PR is draft for publish to next.js/discuss.

# Question
Can I use native lazy loading with `next/image` ?
Canary implementation is always lazy loading by `IntersectionObserver` (if able to use IntersectionObserver) . [refs](https://github.com/vercel/next.js/blob/canary/packages/next/client/image.tsx#L235-L381)


- rewrite and check loading attr in chrome. [source](https://github.com/MaxMEllon/next.js/pull/1/files)

<img width="1351" alt="スクリーンショット 2020-10-28 10 25 03" src="https://user-images.githubusercontent.com/9594376/97382382-a1387380-190e-11eb-943e-01bd4377ea2c.png">


> "auto" is default value in chrome, out of the whatwg spec.

I think the best implementation is switching strategy native or not with feature detection like as `'loading' in HTMLImageElement.prototype`.

What about do you think?
